### PR TITLE
Slight pfp CSS adjustment

### DIFF
--- a/src/RepoSearch/RepoSearch.module.css
+++ b/src/RepoSearch/RepoSearch.module.css
@@ -14,7 +14,7 @@
   flex-direction: column;
 }
 .repoSearch_userInfo_container img {
-  height: 260px;
+  width: 260px;
   aspect-ratio: 1;
   border: solid 2px #3d444d;
   border-radius: 130px;

--- a/src/RepoSearch/RepoSearch.module.less
+++ b/src/RepoSearch/RepoSearch.module.less
@@ -16,7 +16,7 @@
     flex-direction: column;
 
     img {
-        height: 260px;
+        width: 260px;
         aspect-ratio: 1;
         border: solid 2px #3d444d;
         border-radius: 130px;


### PR DESCRIPTION
When in repositories view in responsive, profile image would appear very slightly stretched. Fixed by setting a fixed width instead of height